### PR TITLE
Call parent methods using super().

### DIFF
--- a/businesslogic.py
+++ b/businesslogic.py
@@ -11,7 +11,7 @@ from persistence import MalformedUnitCodeException, NoTelegramGroupException, Ba
 
 class NonAdminUserException(Exception):
     def __init__(self, username, fullname):
-        Exception.__init__(self, f"{username} {fullname} is not an administrator")
+        super().__init__(f"{username} {fullname} is not an administrator")
 
 class User:
     def __init__(self, username:str, fullname:str, logger:Logger):
@@ -97,7 +97,7 @@ class User:
 
 class Admin(User):
     def __init__(self, username:str, fullname:str, logger:Logger):
-        User.__init__(self, username, fullname, logger)
+        super().__init__(username, fullname, logger)
         if username not in getDatabase().getAdmins():
             raise NonAdminUserException(username, fullname)
 

--- a/persistence.py
+++ b/persistence.py
@@ -24,19 +24,19 @@ def _validUnitCode(unitCode:str) -> bool:
 
 class MalformedUnitCodeException(Exception):
     def __init__(self, unitCode:str) -> None:
-        Exception.__init__(self, f"{unitCode} is a malformed unit code")
+        super().__init__(f"{unitCode} is a malformed unit code")
 
 class NoTelegramGroupException(Exception):
     def __init__(self, unitCode:str) -> None:
-        Exception.__init__(self, f"No known telegram group for {unitCode}")
+        super().__init__(f"No known telegram group for {unitCode}")
 
 class BadTelegramLinkException(Exception):
     def __init__(self, unitCode:str, link:str) -> None:
-        Exception.__init__(self, f"Bad link {link} given for {unitCode}")
+        super().__init__(f"Bad link {link} given for {unitCode}")
 
 class BadUnitNameException(Exception):
     def __init__(self, unitCode:str):
-        Exception.__init__(self, f"Bad Unit Name for {unitCode}")
+        super().__init__(f"Bad Unit Name for {unitCode}")
 
 class TelegramGroup:
     def __init__(self, unitCode:str, unitName:str, link:str) -> None:


### PR DESCRIPTION
`super()` should be used to call parent methods. It is more succinct and less error-prone.