### PR TITLE
Implement Singleton as a metaclass instead of a base class.

### DIFF
--- a/persistence.py
+++ b/persistence.py
@@ -104,7 +104,7 @@ class TelegramGroup:
     def __gt__(self, other:"TelegramGroup") -> bool:
         return self._unitCode > other.unitCode
 
-class SingletonDatabase(Singleton):
+class SingletonDatabase(metaclass=Singleton):
     def __init__(self, dbname:str, admins:List[str]):
         self._db = shelve.open(dbname)
         self._admins = admins

--- a/service.py
+++ b/service.py
@@ -25,7 +25,7 @@ def run():
         raise ServiceNotReadyException()
     _SERVICE.run()
     
-class SingletonService(Singleton):
+class SingletonService(metaclass=Singleton):
 
     def __init__(self, token:str, logger:logging.Logger) -> None:
         self._token = token

--- a/singleton.py
+++ b/singleton.py
@@ -1,4 +1,9 @@
-class Singleton:
-   def __new__(cls, *args, **kwargs):
-        instance = super().__new__(cls)
-        return instance
+class Singleton(type):
+    """Metaclass for deriving singleton classes."""
+
+    _instances: dict[type, object] = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]


### PR DESCRIPTION
Per the description, this patch correctly implements `Singleton` as a metaclass.

This works by re-implementing the object's metaclass `__call__` method such that its class `__new__` (and `__init__`) is called only once. Subsequent object creation returns the prior constructed instance:

```python
class Example(metaclass=Singleton):
    pass

a = Example()
b = Example()
assert a is b
```

